### PR TITLE
Avoid using the browser's `location` in the URL replacing function

### DIFF
--- a/src/lib/LocaleSwitcher.svelte
+++ b/src/lib/LocaleSwitcher.svelte
@@ -21,7 +21,7 @@
 
 		if (updateHistoryState) {
 			// update url to reflect locale changes
-			history.pushState({ locale: newLocale }, '', replaceLocaleInUrl(location, newLocale))
+			history.pushState({ locale: newLocale }, '', replaceLocaleInUrl($page.url, newLocale))
 		}
 	}
 
@@ -32,7 +32,7 @@
 	$: if (browser) {
 		const lang = $page.params.lang as Locales
 		switchLocale(lang, false)
-		history.replaceState({ ...history.state, locale: lang }, '', replaceLocaleInUrl(location, lang))
+		history.replaceState({ ...history.state, locale: lang }, '', replaceLocaleInUrl($page.url, lang))
 	}
 </script>
 
@@ -41,9 +41,9 @@
 <ul>
 	{#each locales as l}
 		<li>
-			<button type="button" class:active={l === $locale} on:click={() => switchLocale(l)}>
+			<a class:active={l === $locale} href={`${replaceLocaleInUrl($page.url, l)}`}>
 				{l}
-			</button>
+			</a>
 		</li>
 	{/each}
 </ul>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -28,8 +28,9 @@ header {
 		display: flex;
 		gap: 0.5rem;
 
-		li > button {
+		li > a {
 			all: initial;
+			cursor: pointer;
 			padding: 0.5rem;
 			color: #444;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 // replaces the locale slug in a relative url
 // e.g. /en/blog/article-1 => /de/blog/article-1
-export const replaceLocaleInUrl = ({ pathname, search }: Location, locale: string): string => {
-	const [, , ...rest] = pathname.split('/')
-	return `/${[locale, ...rest].join('/')}${search}`
+export const replaceLocaleInUrl = (url: URL, locale: string): string => {
+	const [, , ...rest] = url.pathname.split('/')
+	return `/${[locale, ...rest].join('/')}${url.search}`
 }


### PR DESCRIPTION
More idiomatic and allows for server-side use (useful for my next proposed changes).

I also refactored the LocaleSwitcher to use `<a>` links instead of buttons, better for accessibility and actually makes sense since the URL changes when they are clicked.